### PR TITLE
Fix installer for bash systems

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -177,14 +177,22 @@ else
     loginshell="${SHELL}"
     loginshell=$(basename ${SHELL})
     if [[ $loginshell == *zsh* ]]; then
-        echo "\n# Following line was automatically added by arttime installer" >>~/.zshrc
-        echo 'export PATH='"$bindir"':$PATH' >>~/.zshrc
-        echo '\nNote: Added export PATH='"$bindir"':$PATH to ~/.zshrc'
-        echo "Installation complete!\nRestart your terminal application, type 'arttime' and press Enter."
+        profile='.zshrc'
     elif [[ $loginshell == *bash* ]]; then
-        echo "\n# Following line was automatically added by arttime installer" >>~/.profile
-        echo 'export PATH='"$bindir"':$PATH' >>~/.profile
-        echo '\nNote: Added export PATH='"$bindir"':$PATH to ~/.profile'
+        if [[ -e $HOME/.bash_profile ]]; then
+            profile='.bash_profile'
+        else
+            profile='.profile'
+        fi
+    elif [[ $loginshell == *ksh* ]]; then
+        profile='.profile'
+    else
+        profile=''
+    fi
+    if [[ ! -z $profile ]]; then
+        echo "\n# Following line was automatically added by arttime installer" >>$HOME/$profile
+        echo 'export PATH='"$bindir"':$PATH' >>$HOME/$profile
+        echo '\nNote: Added export PATH='"$bindir"':$PATH to ~/'"$profile"
         echo "Installation complete!\nRestart your terminal application, type 'arttime' and press Enter."
     else
         echo "\nInstallation [31m*[0malmost[31m*[0m complete! To start using arttime, follow these steps:\n    1) Add $bindir to your PATH environment variable,\n    2) Restart your terminal application, type 'arttime' and press Enter."

--- a/install.sh
+++ b/install.sh
@@ -179,13 +179,12 @@ else
     if [[ $loginshell == *zsh* ]]; then
         profile='.zshrc'
     elif [[ $loginshell == *bash* ]]; then
-        if [[ -e $HOME/.bash_profile ]]; then
-            profile='.bash_profile'
-        else
-            profile='.profile'
-        fi
-    elif [[ $loginshell == *ksh* ]]; then
-        profile='.profile'
+        #if [[ -e $HOME/.bash_profile ]]; then
+        #    profile='.bash_profile'
+        #else
+        #    profile='.profile'
+        #fi
+        profile=".bashrc"
     else
         profile=''
     fi
@@ -193,9 +192,10 @@ else
         echo "\n# Following line was automatically added by arttime installer" >>$HOME/$profile
         echo 'export PATH='"$bindir"':$PATH' >>$HOME/$profile
         echo '\nNote: Added export PATH='"$bindir"':$PATH to ~/'"$profile"
+        echo "      Feel free to move or remove it after next login/reboot to a more appropriate location."
         echo "Installation complete!\nRestart your terminal application, type 'arttime' and press Enter."
     else
-        echo "\nInstallation [31m*[0malmost[31m*[0m complete! To start using arttime, follow these steps:\n    1) Add $bindir to your PATH environment variable,\n    2) Restart your terminal application, type 'arttime' and press Enter."
+        echo "\nInstallation [31m*[0malmost[31m*[0m complete! To start using arttime, follow these steps:\n    1) Add $bindir to your PATH environment variable in appropriate file,\n    2) Open a new terminal session, type 'arttime' and press Enter."
     fi
 fi
 tput cnorm


### PR DESCRIPTION
arttime's online installer does an install under ~/.local. which is not on PATH by profile files if the directory did not exist in past. This comes in the way of user to directly start using arttime in a new interactive non-login terminal session. The workaround is to add a line to .bashrc, and tell the user to move or remove it after their next login or reboot.